### PR TITLE
feat: Added a basic networked pong game

### DIFF
--- a/archaide-backend/internal/game/pong/pong.go
+++ b/archaide-backend/internal/game/pong/pong.go
@@ -166,7 +166,7 @@ func (g *PongGame) Start() {
 
 	g.isRunning = true
 	g.Reset()                                        // Set initial ball and paddle positions/velocities
-	g.ticker = time.NewTicker(16 * time.Millisecond) // ~60 FPS
+	g.ticker = time.NewTicker(60 * time.Millisecond) // ~60 FPS
 	g.playerMux.Unlock()
 
 	log.Printf("[Game %s] Starting game loop.", g.gameID)

--- a/archaide-frontend/src/games/pong/Pong.tsx
+++ b/archaide-frontend/src/games/pong/Pong.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Application, extend } from "@pixi/react";
-import { Container, Graphics, Text} from "pixi.js";
+import { Container, Graphics} from "pixi.js";
 import type { PongStatePayload } from "../../types";
 
 interface PongGameProps {
@@ -11,7 +11,6 @@ interface PongGameProps {
 interface HudProps {
   player1Score: number;
   player2Score: number;
-  countdown: number;
 }
 
 const PaddleWidth = 20;
@@ -24,9 +23,9 @@ const BG_COLOR = 0x181818;
 const PADDLE_COLOR = 0xcccccc;
 const BALL_COLOR = 0xd4ffd4;
 
-extend({ Container, Graphics, Text });
+extend({ Container, Graphics });
 
-function GameHUD({player1Score, player2Score, countdown}: HudProps) {
+function GameHUD({player1Score, player2Score}: HudProps) {
   return (
     <div style={{
       width: 800,
@@ -49,11 +48,11 @@ function GameHUD({player1Score, player2Score, countdown}: HudProps) {
         <span>Spieler 1: {player1Score}</span>
         <span>Spieler 2: {player2Score}</span>
       </div>
-      {countdown > 0 && (
+      {/* {countdown > 0 && (
         <div style={{ fontSize: 48, marginBottom: 8 }}>
           Spiel startet in {countdown}...
         </div>
-      )}
+      )} */}
     </div>
   )
 }
@@ -61,6 +60,7 @@ function GameHUD({player1Score, player2Score, countdown}: HudProps) {
 function PongStage({ gameState, onMove }: PongGameProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      console.log("Key pressed:", e.key);
       if (e.key === "ArrowUp") onMove("up");
       if (e.key === "ArrowDown") onMove("down");
     };
@@ -68,7 +68,7 @@ function PongStage({ gameState, onMove }: PongGameProps) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onMove]);
 
-  return (
+  const pixiContainer = (
     <pixiContainer>
       {/* Paddle 1 */}
       <pixiGraphics
@@ -79,8 +79,9 @@ function PongStage({ gameState, onMove }: PongGameProps) {
           g.fill()
         }}
         x={0}
-        y={gameState.Paddle1Y - (PaddleHeight / 2)}
+        y={gameState.paddle_1_y - (PaddleHeight / 2)}
       />
+      
       {/* Paddle 2 */}
       <pixiGraphics
         draw={(g: Graphics) => {
@@ -89,7 +90,7 @@ function PongStage({ gameState, onMove }: PongGameProps) {
           g.fill();
         }}
         x={800 - PaddleWidth}
-        y={gameState.Paddle2Y - (PaddleHeight / 2)}
+        y={gameState.paddle_2_y - (PaddleHeight / 2)}
       />
       {/* Ball */}
       <pixiGraphics
@@ -98,32 +99,33 @@ function PongStage({ gameState, onMove }: PongGameProps) {
           g.circle(0, 0, BallRadius);
           g.fill();
         }}
-        x={gameState.BallX}
-        y={gameState.BallY}
+        x={gameState.ball_x}
+        y={gameState.ball_y}
       />
     </pixiContainer>
-  );
+  )
+
+  return pixiContainer
 }
 
 export default function PongGame(props: PongGameProps) {
-  const [countdown, setCountdown] = useState(COUNTDOWN_START);
+  //const [countdown, setCountdown] = useState(COUNTDOWN_START);
 
-  useEffect(() => {
-    if (countdown === 0) return;
+  // useEffect(() => {
+  //   if (countdown === 0) return;
 
-    const timer = setInterval(() => {
-      setCountdown((prev) => prev > 0 ? prev -1 : 0);
-    }, 1000);
+  //   const timer = setInterval(() => {
+  //     setCountdown((prev) => prev > 0 ? prev -1 : 0);
+  //   }, 1000);
 
-    return () => clearInterval(timer)
+  //   return () => clearInterval(timer)
 
-  })
+  // })
   return (
     <div style={{ width: 802, margin: "0 auto" }}>
       <GameHUD
-        player1Score={props.gameState.Score1}
-        player2Score={props.gameState.Score2}
-        countdown={countdown}
+        player1Score={props.gameState.score_1}
+        player2Score={props.gameState.score_2}
       />
       <div style={{border: "1px solid white"}}>
       <Application width={800} height={600} backgroundColor={BG_COLOR} antialias>

--- a/archaide-frontend/src/types.ts
+++ b/archaide-frontend/src/types.ts
@@ -17,12 +17,12 @@ export interface ErrorPayload {
 }
 
 export interface PongStatePayload {
-  BallX: number;
-  BallY: number;
-  Paddle1Y: number;
-  Paddle2Y: number;
-  Score1: number;
-  Score2: number;
+  ball_x: number;
+  ball_y: number;
+  paddle_1_y: number;
+  paddle_2_y: number;
+  score_1: number;
+  score_2: number;
 }
 
 export type ServerMessage =

--- a/archaide-frontend/src/views/Lobby.tsx
+++ b/archaide-frontend/src/views/Lobby.tsx
@@ -34,12 +34,12 @@ function Lobby(): JSX.Element {
 
   // Game states
   const [pongState, setPongState] = useState<PongStatePayload>({
-    BallX: 400,
-    BallY: 300,
-    Paddle1Y: 300,
-    Paddle2Y: 300,
-    Score1: 0,
-    Score2: 0
+    ball_x: 400,
+    ball_y: 300,
+    paddle_1_y: 300,
+    paddle_2_y: 300,
+    score_1: 0,
+    score_2: 0
   });
 
   // --- WebSocket Logic ---
@@ -55,6 +55,8 @@ function Lobby(): JSX.Element {
         message = JSON.parse(messageData) as ServerMessage;
 
         logMessage(`<- Received: ${JSON.stringify(message, null, 2)}`);
+
+        console.log("Message received:", message);
 
         switch (message.type) {
           case "welcome": {
@@ -273,7 +275,7 @@ function Lobby(): JSX.Element {
               ))
             ) : (
               <p>No games available to join right now.</p>
-            )}onMove("up")
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR implements a basic pong game. It works, try it out! I had to solve a deadlock issue server sided to be able to handle incoming pong_input messages.

There are quit some things missing, but this will be implemented in a future branch. For example the paddle controls are inverted right now. But for now we have a working pong game! 

We also tested it over the same network! But for this you have to change the URL in Lobby.tsx and add --host flag to the package.json